### PR TITLE
fix: improve trailing and image animation in fathers page background

### DIFF
--- a/src/app/(pages)/fathers-and-figures/Background/Background.tsx
+++ b/src/app/(pages)/fathers-and-figures/Background/Background.tsx
@@ -3,6 +3,7 @@ import React, { useState, useCallback, useRef } from "react";
 import CursorDot from "@/app/my_components/shared/cursorPointers/CursorDot";
 import TrailingImage from "./TrailingImage";
 import { useMouseTrail } from "./useMouseTrail";
+import { AnimatePresence } from 'framer-motion'
 
 interface Trail {
   id: number;
@@ -30,9 +31,11 @@ const Background = (): React.ReactElement => {
       ref={bgtrailsRef}
     >
       <CursorDot current={null} />
-      {trails.map((trail) => (
-        <TrailingImage key={trail.id} trail={trail}/>
-      ))}
+      <AnimatePresence>
+        {trails.map((trail) => (
+          <TrailingImage key={trail.id} trail={trail}/>
+        ))}
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/app/(pages)/fathers-and-figures/Background/TrailingImage.tsx
+++ b/src/app/(pages)/fathers-and-figures/Background/TrailingImage.tsx
@@ -1,5 +1,6 @@
-import React, { useRef, useEffect } from 'react'
+import React from 'react'
 import Image from 'next/image'
+import { motion } from 'framer-motion'
 
 interface TrailingImageProps {
     trail: {
@@ -12,37 +13,29 @@ interface TrailingImageProps {
 
 const TrailingImage: React.FC<TrailingImageProps> = ({ trail }) => {
 
-    const imgRef = useRef<HTMLImageElement>(null);
-
-    useEffect(() => {
-        const timeOut = setTimeout(() => {
-            if (imgRef.current) {
-                imgRef.current.style.opacity = "0";
-            }
-        }, 2000);
-        return () => clearTimeout(timeOut);
-    }, []);
-
-
-
   return (
-    <Image
-        ref={imgRef}
-        src={trail.src}
-        alt="Trail Image"
-        width={300}
-        height={300}
-        className="absolute rounded-sm object-cover shadow-[1px_1px_5px_0px_var(--primary-blue)]"
+    <motion.div
+        initial={{ scale: 0.8, rotate: 3 }}
+        animate={{ opacity: 1, scale: 1, rotate: 0 }}
+        exit={{ opacity: 0, scale: 0, rotate: -30 }}
+        transition={{ duration: 0.3 }}
         style={{
-            left: trail.x,
-            top: trail.y,
+            position: 'absolute',
+            left: trail.x - 150,
+            top: trail.y - 150,
             pointerEvents: "none",
             opacity: 1,
-            transform: "translate(-50%, -50%)",
-            transition: "opacity 0.1s ease-out, transform 0.1s ease-out",
         }}
-    />
-  )
+    >
+        <Image
+            src={trail.src}
+            alt="Trail Image"
+            width={300}
+            height={300}
+            className="rounded-sm object-cover shadow-[1px_1px_5px_0px_var(--primary-blue)]"
+        />
+    </motion.div>
+  );
 }
 
 export default TrailingImage

--- a/src/app/(pages)/fathers-and-figures/Background/generateTrailImage.ts
+++ b/src/app/(pages)/fathers-and-figures/Background/generateTrailImage.ts
@@ -1,7 +1,7 @@
 
 
 
-export const generateTrail = (x: number, y: number) => ({
+export const generateTrailImage = (x: number, y: number) => ({
     id: Date.now() + Math.random(),
     src: `/fathersandfigures/${Math.floor(Math.random() * 22 + 1)}.jpg`,
     x,

--- a/src/app/(pages)/fathers-and-figures/Background/index.ts
+++ b/src/app/(pages)/fathers-and-figures/Background/index.ts
@@ -1,5 +1,5 @@
 export { default as Background } from './Background';
 
-export { generateTrail } from './generateTrail';
+export { generateTrailImage } from './generateTrailImage';
 export { useMouseTrail } from './useMouseTrail';
 export { default as TrailingImage } from './TrailingImage';

--- a/src/app/(pages)/fathers-and-figures/Background/useMouseTrail.ts
+++ b/src/app/(pages)/fathers-and-figures/Background/useMouseTrail.ts
@@ -1,6 +1,6 @@
 'use client'
-import { useEffect } from 'react'
-import { generateTrail } from './generateTrail';
+import { useEffect, useRef } from 'react'
+import { generateTrailImage } from './generateTrailImage';
 
 interface Trail {
     id: number;
@@ -11,16 +11,20 @@ interface Trail {
 
 
 export const useMouseTrail = (bgtrailsRef: React.RefObject<HTMLDivElement | null>, addToTrail: (trail: Trail) => void, removeFromTrail: (id: number) => void) => {
-    useEffect(() => {
+  const mouseMoveCounter = useRef(0)
+  useEffect(() => {
         const handleMouseMove = (event: MouseEvent) => {
           if (bgtrailsRef.current?.contains(event.target as Node)) { 
-            const newTrail: Trail = generateTrail(event.clientX, event.clientY);
-      
-            addToTrail(newTrail);
-      
-            setTimeout(() => {
-                removeFromTrail(newTrail.id);
-            }, 1000);
+            mouseMoveCounter.current++
+              if (mouseMoveCounter.current % 15 === 0){
+              const newTrail: Trail = generateTrailImage(event.clientX, event.clientY);
+        
+              addToTrail(newTrail);
+        
+              setTimeout(() => {
+                  removeFromTrail(newTrail.id);
+              }, 1600);
+            }
           }
         };
         window.addEventListener("mousemove", handleMouseMove);


### PR DESCRIPTION
### Description:
This PR enhances the mouse trail experience on the fathers-and-figures page.

### Changes:
- Replaces manual `setTimeout`-based fading with Framer Motion's animation lifecycle.
- Adds `AnimatePresence` to support graceful exist animations on TrailingImage rendering.
- Adjusts scale, opacity, and rotation for smoother transitions.
- Renames `generateTrail.ts` to `generateTrailImages.ts` for clarity and updates all imports accordingly.