### PR TITLE
docs: add inline docs for generalTrailImage utility and barrel file in Fathers page

### DIFF
--- a/src/app/(pages)/fathers-and-figures/Background/generateTrailImage.ts
+++ b/src/app/(pages)/fathers-and-figures/Background/generateTrailImage.ts
@@ -1,4 +1,15 @@
-
+/**
+ * Creates a single trail image object with a unique ID, positioned at the given (x, y) coordinates
+ * Randomly selects an image from the fathersandfigures directory.
+ * 
+ * @param x - The x-coordinate where the image will be placed.
+ * @param y - The y-coordinate where the image will be placed.
+ * @returns A trail image object contailing:
+ * - id: A unique identifier based on the current timestamp and random number for generating random IDs in a quick timespan
+ * - src: The path to a randomly selected background image from the fathersandfigures directory
+ * - x: The x-coordinate of the image.
+ * - y: THe y-coordinate of the image.
+ */
 
 
 export const generateTrailImage = (x: number, y: number) => ({

--- a/src/app/(pages)/fathers-and-figures/Background/index.ts
+++ b/src/app/(pages)/fathers-and-figures/Background/index.ts
@@ -1,5 +1,8 @@
-export { default as Background } from './Background';
 
+// Components for the Fathers and Figures background and mouse trail effect
+export { default as Background } from './Background';
 export { generateTrailImage } from './generateTrailImage';
+
+// Utility function and custom hook for generating and managing mouse trail images
 export { useMouseTrail } from './useMouseTrail';
 export { default as TrailingImage } from './TrailingImage';


### PR DESCRIPTION
### Summary
This pull request improved the code readability and maintainability by adding inline documentation to key parts of the Fathers page.

### Changes Included
- Documented the `generateTrailImage` utility function, which creates randomly sourced image object from fatherandfigures directory
- Added inline comments in the barrel file, giving an overview of the components, utilities and custom hooks used in Fathers and Figures background logic.