### PR TITLE
Refactor/fatherspage: modulaize ArtCanvas component

### DIFF
--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
@@ -1,33 +1,27 @@
-import React, { useRef, useState, useEffect } from 'react'
+import React, { useRef } from 'react'
 import Seperator from '@/app/my_components/shared/Seperator'
 import Instruction from './Instruction'
 import DraggablePhoto from './DraggablePhoto'
-import { photoStyleProp } from './types'
+import usePhotoStyle from './usePhotoStyleHook'
 
 // ArtCanvas component for the Fathers and Figures page
 const ArtCanvas = () => {
     // Reference tag to the .art-canvas div container where dragable photo elements live
     const artCanvasRef = useRef<HTMLDivElement | null>(null)
 
-    // State to store the style properties for the dragable photo elements
-    const [photoStyle, setPhotoStyle] = useState<photoStyleProp[]>([])
+    // Custom hook to return state to store the style properties for the dragable photo elements
+    const photoStyle = usePhotoStyle()
 
-    // useEffect hook to set the initial style properties for the dragable photo elements upon component mount
-    useEffect(() => {
-        setPhotoStyle(Array.from({ length: 23}, (_, i)=>{
-            return {
-                rotate: Math.random() * 60 - 30,
-                scale: Math.random() * .6 + .8
-            }
-        }))
-    }, [])
-
-  return (
-    <div 
+    return (
+        <div 
         className='art-canvas relative flex flex-wrap gap-5 items-center justify-center p-[5vh] min-h-screen w-screen bg-gradient-to-tl from-blue-300 to-blue-50 rounded-lg overflow-hidden'
         ref={artCanvasRef}
       >
         <Instruction />
+        {/* Generate 23 draggable photocomponets dynamically
+            1. Create an array of 23 elements from 0 to 22
+            2. Map over the array and generate 23 draggable photocomponets dynamically
+        */}
         {Array.from({length: 23}, (_,i) => i).map((i) =>{
             return (
                 <DraggablePhoto

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import Seperator from '@/app/my_components/shared/Seperator'
 import Instruction from './Instruction'
 import DraggablePhoto from './DraggablePhoto'
-import usePhotoStyle from './usePhotoStyleHook'
+import { usePhotoStyle } from './usePhotoStyleHook'
 
 // ArtCanvas component for the Fathers and Figures page
 const ArtCanvas = () => {

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
@@ -1,0 +1,68 @@
+import React, { useRef, useState, useEffect } from 'react'
+import { motion } from 'framer-motion'
+import Image from 'next/image'
+import Seperator from '@/app/my_components/shared/Seperator'
+
+// ArtCanvas component for the Fathers and Figures page
+const ArtCanvas = () => {
+    // Reference tag to the .art-canvas div container where dragable photo elements live
+    const artCanvasRef = useRef<HTMLDivElement | null>(null)
+
+    // Type for image style properties for the dragable photo elements
+    type photoStyleProp = {
+        scale: number,
+        rotate: number,
+    }
+
+    // State to store the style properties for the dragable photo elements
+    const [photoStyle, setPhotoStyle] = useState<photoStyleProp[]>([])
+
+    // useEffect hook to set the initial style properties for the dragable photo elements upon component mount
+    useEffect(() => {
+        setPhotoStyle(Array.from({ length: 23}, (_, i)=>{
+            return {
+                scale: Math.random() * .6 + .8,
+                rotate: Math.random() * 60 - 30
+            }
+        }))
+    }, [])
+
+  return (
+    <div 
+        className='art-canvas relative flex flex-wrap gap-5 items-center justify-center p-[5vh] min-h-screen w-screen bg-gradient-to-tl from-blue-300 to-blue-50 rounded-lg overflow-hidden'
+        ref={artCanvasRef}
+      >
+        {/* Overlapped and ecllipsed instruction for the art canvas aka playground for users to understand the interactivty in the art canvas */}
+        <div 
+          className="instruction absolute lowercase bg-blend-multiply top-[40%] -rotate-2 text-container m-2 !p-14 !text-xl !text-center border-dotted border-[1px] border-[var(--primary-blue)] rounded-sm"
+        >
+          📝🖼️ Craft a story by arranging these frames and watch as your thoughts weave into a father-son tale! 👨‍👦‍📑
+        </div>
+
+        {/* Mapping through the hardcoded length of 23 for an array to map through and render the motion.div container for 23 images from the fathersandfigures directory with stayles borrowed from the above imageStyle state array */}
+        {Array.from({ length: 23 }, (_, i) => i).map((i) => (
+          <motion.div
+            key={i+200}
+            className=''
+            drag
+            dragConstraints={artCanvasRef}
+            style={{ ...photoStyle[i], cursor: 'grab' }}
+            dragElastic={0.1}
+            whileDrag={{ boxShadow: '0px 0px 10px 0px var(--primary-blue)', rotate: 0, scale: 1.1 }}
+          >
+            {/* Nextjs image component for lazy and optimized loading of the images  */}
+            <Image
+              src={`/fathersandfigures/${i + 1}.jpg`}
+              alt={`Image ${i + 1}`}
+              width={200}
+              height={200}
+              className="rounded-sm shadow-[1px_1px_1px_0px_var(--primary-blue)] pointer-events-none"
+            />
+          </motion.div>
+        ))}
+        <Seperator />
+      </div>
+  )
+}
+
+export default ArtCanvas

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
@@ -1,18 +1,13 @@
 import React, { useRef, useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
-import Image from 'next/image'
 import Seperator from '@/app/my_components/shared/Seperator'
+import Instruction from './Instruction'
+import DraggablePhoto from './DraggablePhoto'
+import { photoStyleProp } from './types'
 
 // ArtCanvas component for the Fathers and Figures page
 const ArtCanvas = () => {
     // Reference tag to the .art-canvas div container where dragable photo elements live
     const artCanvasRef = useRef<HTMLDivElement | null>(null)
-
-    // Type for image style properties for the dragable photo elements
-    type photoStyleProp = {
-        scale: number,
-        rotate: number,
-    }
 
     // State to store the style properties for the dragable photo elements
     const [photoStyle, setPhotoStyle] = useState<photoStyleProp[]>([])
@@ -21,8 +16,7 @@ const ArtCanvas = () => {
     useEffect(() => {
         setPhotoStyle(Array.from({ length: 23}, (_, i)=>{
             return {
-                scale: Math.random() * .6 + .8,
-                rotate: Math.random() * 60 - 30
+                transform: `scale(${Math.random() * .6 + .8}) rotate(${Math.random() * 60 - 30}deg)`,
             }
         }))
     }, [])
@@ -32,34 +26,18 @@ const ArtCanvas = () => {
         className='art-canvas relative flex flex-wrap gap-5 items-center justify-center p-[5vh] min-h-screen w-screen bg-gradient-to-tl from-blue-300 to-blue-50 rounded-lg overflow-hidden'
         ref={artCanvasRef}
       >
-        {/* Overlapped and ecllipsed instruction for the art canvas aka playground for users to understand the interactivty in the art canvas */}
-        <div 
-          className="instruction absolute lowercase bg-blend-multiply top-[40%] -rotate-2 text-container m-2 !p-14 !text-xl !text-center border-dotted border-[1px] border-[var(--primary-blue)] rounded-sm"
-        >
-          📝🖼️ Craft a story by arranging these frames and watch as your thoughts weave into a father-son tale! 👨‍👦‍📑
-        </div>
-
-        {/* Mapping through the hardcoded length of 23 for an array to map through and render the motion.div container for 23 images from the fathersandfigures directory with stayles borrowed from the above imageStyle state array */}
-        {Array.from({ length: 23 }, (_, i) => i).map((i) => (
-          <motion.div
-            key={i+200}
-            className=''
-            drag
-            dragConstraints={artCanvasRef}
-            style={{ ...photoStyle[i], cursor: 'grab' }}
-            dragElastic={0.1}
-            whileDrag={{ boxShadow: '0px 0px 10px 0px var(--primary-blue)', rotate: 0, scale: 1.1 }}
-          >
-            {/* Nextjs image component for lazy and optimized loading of the images  */}
-            <Image
-              src={`/fathersandfigures/${i + 1}.jpg`}
-              alt={`Image ${i + 1}`}
-              width={200}
-              height={200}
-              className="rounded-sm shadow-[1px_1px_1px_0px_var(--primary-blue)] pointer-events-none"
-            />
-          </motion.div>
-        ))}
+        <Instruction />
+        {Array.from({length: 23}, (_,i) => i).map((i) =>{
+            return (
+                <DraggablePhoto
+                    key={i+200}
+                    src={`/fathersandfigures/${i + 1}.jpg`}
+                    alt={`Image ${i + 1}`}
+                    style={photoStyle[i]}
+                    dragConstraints={artCanvasRef}
+                />
+            )
+        })}
         <Seperator />
       </div>
   )

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/ArtCanvas.tsx
@@ -16,7 +16,8 @@ const ArtCanvas = () => {
     useEffect(() => {
         setPhotoStyle(Array.from({ length: 23}, (_, i)=>{
             return {
-                transform: `scale(${Math.random() * .6 + .8}) rotate(${Math.random() * 60 - 30}deg)`,
+                rotate: Math.random() * 60 - 30,
+                scale: Math.random() * .6 + .8
             }
         }))
     }, [])
@@ -33,7 +34,7 @@ const ArtCanvas = () => {
                     key={i+200}
                     src={`/fathersandfigures/${i + 1}.jpg`}
                     alt={`Image ${i + 1}`}
-                    style={photoStyle[i]}
+                    animate={photoStyle[i]}
                     dragConstraints={artCanvasRef}
                 />
             )

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/DraggablePhoto.tsx
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/DraggablePhoto.tsx
@@ -4,15 +4,17 @@ import Image from 'next/image'
 import { DraggablePhotoProps } from './types'
 
 // Single draggable photo component for the Fathers and Figures page
-const DraggablePhoto = ({src, alt, style, dragConstraints }: DraggablePhotoProps) => {
+const DraggablePhoto = ({src, alt, animate, dragConstraints }: DraggablePhotoProps) => {
   return (
     <motion.div
         className=''
         drag
         dragConstraints={dragConstraints}
-        style={{ ...style, cursor: 'grab' }}
         dragElastic={0.1}
+        style={{ cursor: 'grab' }}
+        animate={{...animate }}
         whileDrag={{ boxShadow: '0px 0px 10px 0px var(--primary-blue)', rotate: 0, scale: 1.1 }}
+        
     >
     {/* Nextjs image component for lazy and optimized loading of the images  */}
         <Image
@@ -21,6 +23,7 @@ const DraggablePhoto = ({src, alt, style, dragConstraints }: DraggablePhotoProps
             width={200}
             height={200}
             className="rounded-sm shadow-[1px_1px_1px_0px_var(--primary-blue)] pointer-events-none"
+            
         />
     </motion.div>
 )

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/DraggablePhoto.tsx
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/DraggablePhoto.tsx
@@ -1,0 +1,29 @@
+import React, { CSSProperties } from 'react'
+import { motion } from 'framer-motion'
+import Image from 'next/image'
+import { DraggablePhotoProps } from './types'
+
+// Single draggable photo component for the Fathers and Figures page
+const DraggablePhoto = ({src, alt, style, dragConstraints }: DraggablePhotoProps) => {
+  return (
+    <motion.div
+        className=''
+        drag
+        dragConstraints={dragConstraints}
+        style={{ ...style, cursor: 'grab' }}
+        dragElastic={0.1}
+        whileDrag={{ boxShadow: '0px 0px 10px 0px var(--primary-blue)', rotate: 0, scale: 1.1 }}
+    >
+    {/* Nextjs image component for lazy and optimized loading of the images  */}
+        <Image
+            src={src}
+            alt={alt}
+            width={200}
+            height={200}
+            className="rounded-sm shadow-[1px_1px_1px_0px_var(--primary-blue)] pointer-events-none"
+        />
+    </motion.div>
+)
+}
+
+export default DraggablePhoto

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/Instruction.tsx
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/Instruction.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+// Instruction component for ArtCanvas Component that elicits user interaction for moving the draggable photo elements
+const Instruction = () => {
+  return (
+    <div 
+        className="instruction absolute lowercase bg-blend-multiply top-[40%] -rotate-2 text-container m-2 !p-14 !text-xl !text-center border-dotted border-[1px] border-[var(--primary-blue)] rounded-sm"
+    >
+        📝🖼️ Craft a story by arranging these frames and watch as your thoughts weave into a father-son tale! 👨‍👦‍📑
+    </div>
+  )
+}
+
+export default Instruction

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/index.ts
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/index.ts
@@ -1,0 +1,18 @@
+// Barrel file for the ArtCanvas component
+// This file re-exports all the components, hooks and types used in the ArtCanvas component
+// so they can be imported from a single source
+
+// Export the main ArtCanvas component
+export { default as ArtCanvas } from './ArtCanvas';
+
+// Export the DraggablePhoto component used inside ArtCanvas
+export { default as DraggablePhoto } from './DraggablePhoto';
+
+// Export the Instruction component used inside ArtCanvas
+export { default as Instruction } from './Instruction';
+
+// Export the usePhotoStyle hook used inside ArtCanvas for generating and mapping random styles to DraggablePhoto elements
+export { usePhotoStyle } from './usePhotoStyleHook';
+
+// Export the types used inside ArtCanvas for photoStyles and DraggablePhoto component
+export * from './types';

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/types.ts
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/types.ts
@@ -1,8 +1,9 @@
 import { CSSProperties } from 'react'
 
 // Type for image style properties for the dragable photo elements
-export type photoStyleProp = Partial<CSSProperties> & {
-        transform?: string;
+export type photoStyleProp = {
+        rotate: number,
+        scale: number
     }
 
     
@@ -10,6 +11,6 @@ export type photoStyleProp = Partial<CSSProperties> & {
 export type DraggablePhotoProps = {
     src: string;
     alt: string;
-    style: photoStyleProp;
+    animate: photoStyleProp;
     dragConstraints: React.RefObject<HTMLDivElement | null>;
 }

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/types.ts
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/types.ts
@@ -1,0 +1,15 @@
+import { CSSProperties } from 'react'
+
+// Type for image style properties for the dragable photo elements
+export type photoStyleProp = Partial<CSSProperties> & {
+        transform?: string;
+    }
+
+    
+// Type for the props of the draggable photo component
+export type DraggablePhotoProps = {
+    src: string;
+    alt: string;
+    style: photoStyleProp;
+    dragConstraints: React.RefObject<HTMLDivElement | null>;
+}

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/usePhotoStyleHook.ts
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/usePhotoStyleHook.ts
@@ -18,4 +18,4 @@
         return photoStyle
     }
 
-    export default usePhotoStyle
+    export { usePhotoStyle }

--- a/src/app/(pages)/fathers-and-figures/ArtCanvas/usePhotoStyleHook.ts
+++ b/src/app/(pages)/fathers-and-figures/ArtCanvas/usePhotoStyleHook.ts
@@ -1,0 +1,21 @@
+    import { useState, useEffect } from "react"
+    import { photoStyleProp } from "./types"
+
+    const usePhotoStyle = () => {
+        // State to store the style properties for the draggable photo elements
+        const [photoStyle, setPhotoStyle] = useState<photoStyleProp[]>([])
+
+        // useEffect hook to set the initial style properties for the dragable photo elements upon component mount
+        useEffect(() => {
+            setPhotoStyle(Array.from({ length: 23}, (_, i)=>{
+                return {
+                    rotate: Math.random() * 60 - 30,
+                    scale: Math.random() * .6 + .8
+                }
+            }))
+        }, [])
+
+        return photoStyle
+    }
+
+    export default usePhotoStyle

--- a/src/app/(pages)/fathers-and-figures/HeroSection.tsx
+++ b/src/app/(pages)/fathers-and-figures/HeroSection.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import TitleDiscription from '@/app/my_components/shared/TitleDiscription'
+import { Background } from './Background'
+
+// Static Content: Data for rendering the page title and page description in English and Marathi for Fathers and Figures page.
+const content = {
+    title: "Fathers and Figures",
+    description: {
+      eng: "Intergenerational caste-patriarchal trauma hollows the very substance from our relationship with our fathers, generations after generations. The collective emotional hijacking of our fathers by the caste-patriarchal forces have badly crippled our emotional development in turn. The deliberate dumbing and numbing of the self, as a response to either obey or tolerate these casteist and patriarchal structures is our own inherited unhealed trauma too. Across the social spectrum, extra-familial patriarchal personalities as father figures occupy the vacuum left by emotionally absent men within our families who were already kidnapped away or baptized by caste-patriarchal systems for its own agenda.\n\nStrong savior icons with political and spiritual persona, figuratively come to occupy this vacant/inactive position of a father figure and ultimately to rescue his followers. There is often a risk that these father figures would reinforce similar paternal and hero-worshipping hierarchical norms. On the other hand, Dr Ambedkar, as an ideal father figure, with incredible grace and compassion in his imagery, has been easily accessible to his follower through his ideals. Yet, the complete lack of substance in my relationship with my own father continues to tremble me. As I am approaching my father's age when he had become a father himself, I realize that I have been growing into a similar emotional space as he already had. I am reciprocating the inactivity in the bond and contributing to it's hollowness in similar ways.\n\nThe father-son/daughter crisis is our collective wound and still there is so much scope for individual nuance as well. I invite you to move the photo-pieces in my story and see if it turns into yours.",
+      mar: "पिढ्यान पिढ्या बापलेक/बापलेकीच्या नात्यांतला गाभाच पिढीजात जातीय-पुरुषकेंद्री आघात पोखरत राहिले आहेत. आपल्या बापमंडळींचं जातीय-पुरुषधार्जिण्या संस्कृतीने केलेलं सामूहिक अपहरण अथवा पदहरण हे आपल्या भावनिक विकासाच्या अपूर्णतेची कारणमिमांसा आहे. मुद्दामहून मंद आणि संथ करवलेली आपली मने, आणि काही वेळी कट्टरतेने पुरस्कार, असे प्रतिसाद खरे तर अश्या जातीय-पुरुषी व्यवस्थेच्या एकतर अंकुशांत किंवा सहनशीलतेतून घडलेली पिढीजात भावनिक व्रणांचीच देण आहे. समाजातल्या कुठल्याही स्तरात असो, जातीय-पुरुषकेंद्री व्यवस्थेने स्वतःच्याच मशागतीसाठी पळवलेल्या किंवा वळवलेल्या, आणि त्यामुळे भावनिक दृष्ट्या घरातून बुट्टी असलेल्या माणसांच्या रिकाम्या जागांवर मग बड्या पुरुषी व्यक्तिमत्त्वांनी पिता-समान स्थान निर्माण केलेले असते.\n\nअशा वेळी राजकीय आणि अध्यात्मिक मार्गदाते लाक्षणिकरित्या हि वडील व्यक्तीची रिकामी/अव्यक्त जागा भरून काढतात आणि त्यांच्या अनुयायांना आधार देतात. परंतु बहुतेकदा हेच बडे पितासमान मंडळी त्याच पुरुषी आणि व्यक्तिपूजेच्या उतरंडीत स्वतःला रुजवतात. अश्या बड्या आणि जोखमीच्या बाप्यांच्या गर्दीत, बाबासाहेब एक काळजीवाहू आणि आदर्श पिताकृती म्हणून आपल्या विचारांच्या आणि आदर्शाच्या माध्यमातून सामान्य आंबेडकरवाद्याला सहज भेटण्याजोगे आहेत. तरीही, जवळपास सगळंच पोकळ असलेलं माझ्या वडिलांशी असलेलं माझं नातं अजूनही अंगावर शहारे आणतं. माझ्या जन्माच्या वेळी माझे वडील होते त्या वयाचं होत असताना आता लक्षात येतंय कि मी देखील भावनिकरीत्या त्याच छापाचा होत आहे. आमच्या दोघांमधल्या नात्यातल्या पोकळपणाला आणि थंडपणाला माझादेखील तेवढाच हातभार आहे, मीदेखील तितकाच जबाबदार आहे.\n\nबापलेक/बापलेकीच्या नात्यावरच हे ग्रहण हे बहुतेक आपल्या सगळ्यांचीच सामाईक जखम असूनही आपल्या प्रत्येकाच्या घरातली कहाणी थोडी-थोडी वेगळी असेल. मी वरवर सांगू पाहत असलेली हि माझी चित्रकथा, ज्याचे हिस्से खालीवर ड्रॅग करून कदाचित तुम्हाला तुमचीही कथा सापडेल ह्या अपेक्षेने इथे मांडतोय.",
+    },
+  }
+
+// Hero Section of the Fathers and Figures page with Title and Description rendered overlayed on a custom Background component
+const HeroSection = () => {
+  return (
+    <TitleDiscription
+        title={content.title}
+        description={content.description}
+        background={<Background />}
+    />
+  )
+}
+
+export default HeroSection

--- a/src/app/(pages)/fathers-and-figures/page.tsx
+++ b/src/app/(pages)/fathers-and-figures/page.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import SubmitCards from './SubmitCards';
 import HeroSection from './HeroSection';
-import ArtCanvas from './ArtCanvas/ArtCanvas';
+import { ArtCanvas } from './ArtCanvas';
 
 
 // Main landing page component for the "Fathers and Figures" page.

--- a/src/app/(pages)/fathers-and-figures/page.tsx
+++ b/src/app/(pages)/fathers-and-figures/page.tsx
@@ -1,96 +1,21 @@
 'use client'
-import React, { useEffect, useState, useRef } from 'react';
-import TitleDiscription from '@/app/my_components/shared/TitleDiscription';
+import React from 'react';
 import Seperator from '@/app/my_components/shared/Seperator'
 import Image from 'next/image';
-import { motion } from 'framer-motion';
-import { Background } from './Background';
 import Link from 'next/link';
 import SubmitCards from './SubmitCards';
 import HeroSection from './HeroSection';
+import ArtCanvas from './ArtCanvas/ArtCanvas';
 
 
 // Main landing page component for the "Fathers and Figures" page.
 
 export default function Home() {
 
-  // Static content: Data for Page title and English and Marathi Description section on the page
-  // const content = {
-  //   title: "Fathers and Figures",
-  //   description: {
-  //     eng: "Intergenerational caste-patriarchal trauma hollows the very substance from our relationship with our fathers, generations after generations. The collective emotional hijacking of our fathers by the caste-patriarchal forces have badly crippled our emotional development in turn. The deliberate dumbing and numbing of the self, as a response to either obey or tolerate these casteist and patriarchal structures is our own inherited unhealed trauma too. Across the social spectrum, extra-familial patriarchal personalities as father figures occupy the vacuum left by emotionally absent men within our families who were already kidnapped away or baptized by caste-patriarchal systems for its own agenda.\n\nStrong savior icons with political and spiritual persona, figuratively come to occupy this vacant/inactive position of a father figure and ultimately to rescue his followers. There is often a risk that these father figures would reinforce similar paternal and hero-worshipping hierarchical norms. On the other hand, Dr Ambedkar, as an ideal father figure, with incredible grace and compassion in his imagery, has been easily accessible to his follower through his ideals. Yet, the complete lack of substance in my relationship with my own father continues to tremble me. As I am approaching my father's age when he had become a father himself, I realize that I have been growing into a similar emotional space as he already had. I am reciprocating the inactivity in the bond and contributing to it's hollowness in similar ways.\n\nThe father-son/daughter crisis is our collective wound and still there is so much scope for individual nuance as well. I invite you to move the photo-pieces in my story and see if it turns into yours.",
-  //     mar: "पिढ्यान पिढ्या बापलेक/बापलेकीच्या नात्यांतला गाभाच पिढीजात जातीय-पुरुषकेंद्री आघात पोखरत राहिले आहेत. आपल्या बापमंडळींचं जातीय-पुरुषधार्जिण्या संस्कृतीने केलेलं सामूहिक अपहरण अथवा पदहरण हे आपल्या भावनिक विकासाच्या अपूर्णतेची कारणमिमांसा आहे. मुद्दामहून मंद आणि संथ करवलेली आपली मने, आणि काही वेळी कट्टरतेने पुरस्कार, असे प्रतिसाद खरे तर अश्या जातीय-पुरुषी व्यवस्थेच्या एकतर अंकुशांत किंवा सहनशीलतेतून घडलेली पिढीजात भावनिक व्रणांचीच देण आहे. समाजातल्या कुठल्याही स्तरात असो, जातीय-पुरुषकेंद्री व्यवस्थेने स्वतःच्याच मशागतीसाठी पळवलेल्या किंवा वळवलेल्या, आणि त्यामुळे भावनिक दृष्ट्या घरातून बुट्टी असलेल्या माणसांच्या रिकाम्या जागांवर मग बड्या पुरुषी व्यक्तिमत्त्वांनी पिता-समान स्थान निर्माण केलेले असते.\n\nअशा वेळी राजकीय आणि अध्यात्मिक मार्गदाते लाक्षणिकरित्या हि वडील व्यक्तीची रिकामी/अव्यक्त जागा भरून काढतात आणि त्यांच्या अनुयायांना आधार देतात. परंतु बहुतेकदा हेच बडे पितासमान मंडळी त्याच पुरुषी आणि व्यक्तिपूजेच्या उतरंडीत स्वतःला रुजवतात. अश्या बड्या आणि जोखमीच्या बाप्यांच्या गर्दीत, बाबासाहेब एक काळजीवाहू आणि आदर्श पिताकृती म्हणून आपल्या विचारांच्या आणि आदर्शाच्या माध्यमातून सामान्य आंबेडकरवाद्याला सहज भेटण्याजोगे आहेत. तरीही, जवळपास सगळंच पोकळ असलेलं माझ्या वडिलांशी असलेलं माझं नातं अजूनही अंगावर शहारे आणतं. माझ्या जन्माच्या वेळी माझे वडील होते त्या वयाचं होत असताना आता लक्षात येतंय कि मी देखील भावनिकरीत्या त्याच छापाचा होत आहे. आमच्या दोघांमधल्या नात्यातल्या पोकळपणाला आणि थंडपणाला माझादेखील तेवढाच हातभार आहे, मीदेखील तितकाच जबाबदार आहे.\n\nबापलेक/बापलेकीच्या नात्यावरच हे ग्रहण हे बहुतेक आपल्या सगळ्यांचीच सामाईक जखम असूनही आपल्या प्रत्येकाच्या घरातली कहाणी थोडी-थोडी वेगळी असेल. मी वरवर सांगू पाहत असलेली हि माझी चित्रकथा, ज्याचे हिस्से खालीवर ड्रॅग करून कदाचित तुम्हाला तुमचीही कथा सापडेल ह्या अपेक्षेने इथे मांडतोय.",
-  //   },
-  // }
-  
-  // a reference to the art canvas showcase of the page, where draggable images live
-  const playgroundRef = useRef<HTMLDivElement | null>(null)
-
-  // Tyoe defined for the dynamic styling object of images in imageStyle state array that defines scale, rotation and cursor style
-  type imageSizeProp = {
-    scale: number
-    rotate: number
-    cursor: string
-  }
-
-  // a state to store and update the generated style of the images
-  const [imageStyle, setImageStyle] = useState<imageSizeProp[]>([])
-
-  // On every component mount useEffect hook to it assigns scale randomly from the range 0.8 to 1.4, and randome rotation from range -30 to +30. All images have cursor grab assigned to them. 
-  useEffect(() => {
-    setImageStyle(Array.from({ length: 23 }, (_, i) => ({
-      scale: Math.random() * .6 + .8,
-      rotate: Math.random() * 60 - 30,
-      cursor: 'grab'
-    })));
-  }, []);
-
   return (
     <>
-      {/* Section 1: Renders the Title and Discription Element on the page along with background section as a child */}
-      {/* <TitleDiscription
-        title={content.title}
-        description={content.description}
-        background={<Background />}
-      /> */}
       <HeroSection />
-
-      {/*Section 2: Interactive art canvas page that takes useRef to apply constraints on the dragconstraints for the images inside it */}
-      <div 
-        className='playground relative flex flex-wrap gap-5 items-center justify-center p-[5vh] min-h-screen w-screen bg-gradient-to-tl from-blue-300 to-blue-50 rounded-lg overflow-hidden'
-        ref={playgroundRef}
-      >
-        {/* Overlapped and ecllipsed instruction for the art canvas aka playground for users to understand the interactivty in the art canvas */}
-        <div 
-          className="instruction absolute lowercase bg-blend-multiply top-[40%] -rotate-2 text-container m-2 !p-14 !text-xl !text-center border-dotted border-[1px] border-[var(--primary-blue)] rounded-sm"
-        >
-          📝🖼️ Craft a story by arranging these frames and watch as your thoughts weave into a father-son tale! 👨‍👦‍📑
-        </div>
-
-        {/* Mapping through the hardcoded length of 23 for an array to map through and render the motion.div container for 23 images from the fathersandfigures directory with stayles borrowed from the above imageStyle state array */}
-        {Array.from({ length: 23 }, (_, i) => i).map((i) => (
-          <motion.div
-            key={i+200}
-            className=''
-            drag
-            dragConstraints={playgroundRef}
-            style={{ ...imageStyle[i] }}
-            dragElastic={0.1}
-            whileDrag={{ boxShadow: '0px 0px 10px 0px var(--primary-blue)', rotate: 0, scale: 1.1 }}
-          >
-            {/* Nextjs image component for lazy and optimized loading of the images  */}
-            <Image
-              src={`/fathersandfigures/${i + 1}.jpg`}
-              alt={`Image ${i + 1}`}
-              width={200}
-              height={200}
-              className="rounded-sm shadow-[1px_1px_1px_0px_var(--primary-blue)] pointer-events-none"
-            />
-          </motion.div>
-        ))}
-        <Seperator />
-      </div>
-
+      <ArtCanvas />
       {/* Section 3: Submit your own story here: */}
       
       <div className="relative isolate text-container grid md:grid-cols-2 my-2 md:flex-row flex-col items-center justify-center gap-5">

--- a/src/app/(pages)/fathers-and-figures/page.tsx
+++ b/src/app/(pages)/fathers-and-figures/page.tsx
@@ -7,27 +7,36 @@ import { motion } from 'framer-motion';
 import { Background } from './Background';
 import Link from 'next/link';
 import SubmitCards from './SubmitCards';
+import HeroSection from './HeroSection';
 
+
+// Main landing page component for the "Fathers and Figures" page.
 
 export default function Home() {
-  const content = {
-    title: "Fathers and Figures",
-    description: {
-      eng: "Intergenerational caste-patriarchal trauma hollows the very substance from our relationship with our fathers, generations after generations. The collective emotional hijacking of our fathers by the caste-patriarchal forces have badly crippled our emotional development in turn. The deliberate dumbing and numbing of the self, as a response to either obey or tolerate these casteist and patriarchal structures is our own inherited unhealed trauma too. Across the social spectrum, extra-familial patriarchal personalities as father figures occupy the vacuum left by emotionally absent men within our families who were already kidnapped away or baptized by caste-patriarchal systems for its own agenda.\n\nStrong savior icons with political and spiritual persona, figuratively come to occupy this vacant/inactive position of a father figure and ultimately to rescue his followers. There is often a risk that these father figures would reinforce similar paternal and hero-worshipping hierarchical norms. On the other hand, Dr Ambedkar, as an ideal father figure, with incredible grace and compassion in his imagery, has been easily accessible to his follower through his ideals. Yet, the complete lack of substance in my relationship with my own father continues to tremble me. As I am approaching my father's age when he had become a father himself, I realize that I have been growing into a similar emotional space as he already had. I am reciprocating the inactivity in the bond and contributing to it's hollowness in similar ways.\n\nThe father-son/daughter crisis is our collective wound and still there is so much scope for individual nuance as well. I invite you to move the photo-pieces in my story and see if it turns into yours.",
-      mar: "पिढ्यान पिढ्या बापलेक/बापलेकीच्या नात्यांतला गाभाच पिढीजात जातीय-पुरुषकेंद्री आघात पोखरत राहिले आहेत. आपल्या बापमंडळींचं जातीय-पुरुषधार्जिण्या संस्कृतीने केलेलं सामूहिक अपहरण अथवा पदहरण हे आपल्या भावनिक विकासाच्या अपूर्णतेची कारणमिमांसा आहे. मुद्दामहून मंद आणि संथ करवलेली आपली मने, आणि काही वेळी कट्टरतेने पुरस्कार, असे प्रतिसाद खरे तर अश्या जातीय-पुरुषी व्यवस्थेच्या एकतर अंकुशांत किंवा सहनशीलतेतून घडलेली पिढीजात भावनिक व्रणांचीच देण आहे. समाजातल्या कुठल्याही स्तरात असो, जातीय-पुरुषकेंद्री व्यवस्थेने स्वतःच्याच मशागतीसाठी पळवलेल्या किंवा वळवलेल्या, आणि त्यामुळे भावनिक दृष्ट्या घरातून बुट्टी असलेल्या माणसांच्या रिकाम्या जागांवर मग बड्या पुरुषी व्यक्तिमत्त्वांनी पिता-समान स्थान निर्माण केलेले असते.\n\nअशा वेळी राजकीय आणि अध्यात्मिक मार्गदाते लाक्षणिकरित्या हि वडील व्यक्तीची रिकामी/अव्यक्त जागा भरून काढतात आणि त्यांच्या अनुयायांना आधार देतात. परंतु बहुतेकदा हेच बडे पितासमान मंडळी त्याच पुरुषी आणि व्यक्तिपूजेच्या उतरंडीत स्वतःला रुजवतात. अश्या बड्या आणि जोखमीच्या बाप्यांच्या गर्दीत, बाबासाहेब एक काळजीवाहू आणि आदर्श पिताकृती म्हणून आपल्या विचारांच्या आणि आदर्शाच्या माध्यमातून सामान्य आंबेडकरवाद्याला सहज भेटण्याजोगे आहेत. तरीही, जवळपास सगळंच पोकळ असलेलं माझ्या वडिलांशी असलेलं माझं नातं अजूनही अंगावर शहारे आणतं. माझ्या जन्माच्या वेळी माझे वडील होते त्या वयाचं होत असताना आता लक्षात येतंय कि मी देखील भावनिकरीत्या त्याच छापाचा होत आहे. आमच्या दोघांमधल्या नात्यातल्या पोकळपणाला आणि थंडपणाला माझादेखील तेवढाच हातभार आहे, मीदेखील तितकाच जबाबदार आहे.\n\nबापलेक/बापलेकीच्या नात्यावरच हे ग्रहण हे बहुतेक आपल्या सगळ्यांचीच सामाईक जखम असूनही आपल्या प्रत्येकाच्या घरातली कहाणी थोडी-थोडी वेगळी असेल. मी वरवर सांगू पाहत असलेली हि माझी चित्रकथा, ज्याचे हिस्से खालीवर ड्रॅग करून कदाचित तुम्हाला तुमचीही कथा सापडेल ह्या अपेक्षेने इथे मांडतोय.",
-    },
-  }
+
+  // Static content: Data for Page title and English and Marathi Description section on the page
+  // const content = {
+  //   title: "Fathers and Figures",
+  //   description: {
+  //     eng: "Intergenerational caste-patriarchal trauma hollows the very substance from our relationship with our fathers, generations after generations. The collective emotional hijacking of our fathers by the caste-patriarchal forces have badly crippled our emotional development in turn. The deliberate dumbing and numbing of the self, as a response to either obey or tolerate these casteist and patriarchal structures is our own inherited unhealed trauma too. Across the social spectrum, extra-familial patriarchal personalities as father figures occupy the vacuum left by emotionally absent men within our families who were already kidnapped away or baptized by caste-patriarchal systems for its own agenda.\n\nStrong savior icons with political and spiritual persona, figuratively come to occupy this vacant/inactive position of a father figure and ultimately to rescue his followers. There is often a risk that these father figures would reinforce similar paternal and hero-worshipping hierarchical norms. On the other hand, Dr Ambedkar, as an ideal father figure, with incredible grace and compassion in his imagery, has been easily accessible to his follower through his ideals. Yet, the complete lack of substance in my relationship with my own father continues to tremble me. As I am approaching my father's age when he had become a father himself, I realize that I have been growing into a similar emotional space as he already had. I am reciprocating the inactivity in the bond and contributing to it's hollowness in similar ways.\n\nThe father-son/daughter crisis is our collective wound and still there is so much scope for individual nuance as well. I invite you to move the photo-pieces in my story and see if it turns into yours.",
+  //     mar: "पिढ्यान पिढ्या बापलेक/बापलेकीच्या नात्यांतला गाभाच पिढीजात जातीय-पुरुषकेंद्री आघात पोखरत राहिले आहेत. आपल्या बापमंडळींचं जातीय-पुरुषधार्जिण्या संस्कृतीने केलेलं सामूहिक अपहरण अथवा पदहरण हे आपल्या भावनिक विकासाच्या अपूर्णतेची कारणमिमांसा आहे. मुद्दामहून मंद आणि संथ करवलेली आपली मने, आणि काही वेळी कट्टरतेने पुरस्कार, असे प्रतिसाद खरे तर अश्या जातीय-पुरुषी व्यवस्थेच्या एकतर अंकुशांत किंवा सहनशीलतेतून घडलेली पिढीजात भावनिक व्रणांचीच देण आहे. समाजातल्या कुठल्याही स्तरात असो, जातीय-पुरुषकेंद्री व्यवस्थेने स्वतःच्याच मशागतीसाठी पळवलेल्या किंवा वळवलेल्या, आणि त्यामुळे भावनिक दृष्ट्या घरातून बुट्टी असलेल्या माणसांच्या रिकाम्या जागांवर मग बड्या पुरुषी व्यक्तिमत्त्वांनी पिता-समान स्थान निर्माण केलेले असते.\n\nअशा वेळी राजकीय आणि अध्यात्मिक मार्गदाते लाक्षणिकरित्या हि वडील व्यक्तीची रिकामी/अव्यक्त जागा भरून काढतात आणि त्यांच्या अनुयायांना आधार देतात. परंतु बहुतेकदा हेच बडे पितासमान मंडळी त्याच पुरुषी आणि व्यक्तिपूजेच्या उतरंडीत स्वतःला रुजवतात. अश्या बड्या आणि जोखमीच्या बाप्यांच्या गर्दीत, बाबासाहेब एक काळजीवाहू आणि आदर्श पिताकृती म्हणून आपल्या विचारांच्या आणि आदर्शाच्या माध्यमातून सामान्य आंबेडकरवाद्याला सहज भेटण्याजोगे आहेत. तरीही, जवळपास सगळंच पोकळ असलेलं माझ्या वडिलांशी असलेलं माझं नातं अजूनही अंगावर शहारे आणतं. माझ्या जन्माच्या वेळी माझे वडील होते त्या वयाचं होत असताना आता लक्षात येतंय कि मी देखील भावनिकरीत्या त्याच छापाचा होत आहे. आमच्या दोघांमधल्या नात्यातल्या पोकळपणाला आणि थंडपणाला माझादेखील तेवढाच हातभार आहे, मीदेखील तितकाच जबाबदार आहे.\n\nबापलेक/बापलेकीच्या नात्यावरच हे ग्रहण हे बहुतेक आपल्या सगळ्यांचीच सामाईक जखम असूनही आपल्या प्रत्येकाच्या घरातली कहाणी थोडी-थोडी वेगळी असेल. मी वरवर सांगू पाहत असलेली हि माझी चित्रकथा, ज्याचे हिस्से खालीवर ड्रॅग करून कदाचित तुम्हाला तुमचीही कथा सापडेल ह्या अपेक्षेने इथे मांडतोय.",
+  //   },
+  // }
   
+  // a reference to the art canvas showcase of the page, where draggable images live
   const playgroundRef = useRef<HTMLDivElement | null>(null)
 
+  // Tyoe defined for the dynamic styling object of images in imageStyle state array that defines scale, rotation and cursor style
   type imageSizeProp = {
     scale: number
     rotate: number
     cursor: string
   }
 
+  // a state to store and update the generated style of the images
   const [imageStyle, setImageStyle] = useState<imageSizeProp[]>([])
 
+  // On every component mount useEffect hook to it assigns scale randomly from the range 0.8 to 1.4, and randome rotation from range -30 to +30. All images have cursor grab assigned to them. 
   useEffect(() => {
     setImageStyle(Array.from({ length: 23 }, (_, i) => ({
       scale: Math.random() * .6 + .8,
@@ -38,23 +47,27 @@ export default function Home() {
 
   return (
     <>
-
-      <TitleDiscription
+      {/* Section 1: Renders the Title and Discription Element on the page along with background section as a child */}
+      {/* <TitleDiscription
         title={content.title}
         description={content.description}
         background={<Background />}
-      />
+      /> */}
+      <HeroSection />
 
-      
+      {/*Section 2: Interactive art canvas page that takes useRef to apply constraints on the dragconstraints for the images inside it */}
       <div 
         className='playground relative flex flex-wrap gap-5 items-center justify-center p-[5vh] min-h-screen w-screen bg-gradient-to-tl from-blue-300 to-blue-50 rounded-lg overflow-hidden'
         ref={playgroundRef}
       >
+        {/* Overlapped and ecllipsed instruction for the art canvas aka playground for users to understand the interactivty in the art canvas */}
         <div 
           className="instruction absolute lowercase bg-blend-multiply top-[40%] -rotate-2 text-container m-2 !p-14 !text-xl !text-center border-dotted border-[1px] border-[var(--primary-blue)] rounded-sm"
         >
-          📝🖼️ Craft a story by arranging these frames and watch as your thoughts weave into a father-son tale! 👨🏽‍👦🏽📑
+          📝🖼️ Craft a story by arranging these frames and watch as your thoughts weave into a father-son tale! 👨‍👦‍📑
         </div>
+
+        {/* Mapping through the hardcoded length of 23 for an array to map through and render the motion.div container for 23 images from the fathersandfigures directory with stayles borrowed from the above imageStyle state array */}
         {Array.from({ length: 23 }, (_, i) => i).map((i) => (
           <motion.div
             key={i+200}
@@ -65,6 +78,7 @@ export default function Home() {
             dragElastic={0.1}
             whileDrag={{ boxShadow: '0px 0px 10px 0px var(--primary-blue)', rotate: 0, scale: 1.1 }}
           >
+            {/* Nextjs image component for lazy and optimized loading of the images  */}
             <Image
               src={`/fathersandfigures/${i + 1}.jpg`}
               alt={`Image ${i + 1}`}
@@ -77,6 +91,8 @@ export default function Home() {
         <Seperator />
       </div>
 
+      {/* Section 3: Submit your own story here: */}
+      
       <div className="relative isolate text-container grid md:grid-cols-2 my-2 md:flex-row flex-col items-center justify-center gap-5">
         <div className="flex-1 w-full max-h-[75vh] aspect-[7/12] border-[1px] border-[var(--primary-blue)] rounded-sm overflow-hidden">
           <iframe
@@ -111,6 +127,7 @@ export default function Home() {
         <Seperator />
       </div>
 
+      {/* Section 4: Maraa BIC Exhibition Photos */}
       <div className='relative isolate p-5 flex flex-col items-center justify-center'>
         <div className="text-container my-2 p-1 border-[1px] border-[var(--primary-blue)] hover:bg-[var(--primary-blue)] hover:text-[var(--primary-white)] rounded-sm transition-all duration-300 ease-in-out">
             <div className='text-xs opacity-80 text-center'>This project was nurtured with the support of <Link target='_blank' href="https://maraa.in/portfolio/mirrors-fellowship/" className="link-text">Maraa&apos;s Mirrors</Link> (2024) — A Creative Fellowship on Masculinity.</div>
@@ -133,7 +150,7 @@ export default function Home() {
           />
         </div>
         <div className='text-container !text-xs !text-center p-1'>Scenes from the <Link className='link-text' target='_blank' href="https://bangaloreinternationalcentre.org/event/mirrors/">Mirrors Group Show</Link> on Experiences & Expressions of Masculine & Feminine at Bangalore International Center, November 2024. <span className="opacity-50">Image courtesy of <span className="italic">Angarika</span> from the Maraa team.</span></div>
-        
+        {/* Maraa Post Fellowship Interview Video */}
         <div className="maraa-video border-[1px] border-dotted rounded-sm border-[var(--primary-blue)] mt-5 p-1 w-full aspect-[16/10] text-container flex flex-col items-center justify-center">
             <iframe
               className='rounded-sm w-full mx-auto object-cover'


### PR DESCRIPTION
### Summary
This PR refactors the `ArtCanvas` component in `fathers-and-figures` page to improve modularity and maintainability.

### Changes
- Extracted `ArtCanvas` from the `fathers-and-figures` page into its own components folder
- Created a barrel file (`index.ts`) for `ArtCanvas` components for simplified imports.
- Split `ArtCanvas` into smaller components:
  - `DraggablePhoto`
  - `Instruction`
  - Type definitions moved into separate `types.ts` file
  - Extracted a new custom hook `usePhotoStyle` for managing photo styling logic